### PR TITLE
Fix for PHP's open_basedir error when creating tmp file

### DIFF
--- a/inc_functions.php
+++ b/inc_functions.php
@@ -123,7 +123,7 @@ function checkUpdate($bForce = false) {
     global $oLog;
     $sUrlCheck = str_replace(" ", "%20", $aEnv['links']['update']['check']['url']);
     $iTtl = (int) $aCfg["checkupdate"];
-    $sTarget = sys_get_temp_dir() . "/checkupdate_" . md5($sUrlCheck) . ".tmp";
+    $sTarget = "checkupdate_" . md5($sUrlCheck) . ".tmp";
 
     // if the user does not want an update check then respect it
     if (!$iTtl && !$bForce) {


### PR DESCRIPTION
Fixes #1 - the **checkupdate_*.tmp** file now get's created in the document root