### PR TITLE
2019-01-03: v2.03.00 - update metadata

### DIFF
--- a/config/internal-env.json
+++ b/config/internal-env.json
@@ -2,7 +2,7 @@
     "project": {
         "title": "Pimped Apache Status",
         "version": "2.03.00",
-        "releasedate": "2018-12-27",
+        "releasedate": "2019-01-03",
         "license": "GPL 3.0"
     },
     "active": [],

--- a/history.txt
+++ b/history.txt
@@ -10,6 +10,12 @@
 
 ----------------------------------------------------------------------
 
+2019-01-03: v2.03.00
+  * UPDATE: Login with Basic Auth was replaced by Login form (for FCGI)
+  * FIX: user setup at initial setup
+  * FIX: remove warnings if bookmarklet is used
+  * ADDED: Show warnings in formulars if SSL is not used
+
 2018-12-27: v2.02.00
   * ADDED section in server info page: it shows current group and its servers
   * ADDED config value: hideRows to remove rows by given rules


### PR DESCRIPTION
  * UPDATE: Login with Basic Auth was replaced by Login form (for FCGI)
  * FIX: user setup at initial setup
  * FIX: remove warnings if bookmarklet is used
  * ADDED: Show warnings in formulars if SSL is not used