### PR TITLE
[fix] Ignore closed requests

### DIFF
--- a/classes/serverstatus.class.php
+++ b/classes/serverstatus.class.php
@@ -179,6 +179,8 @@ class ServerStatus {
             if ($formatOk) {
                 foreach ($matches[0] as $sRequestData) {
                     $formatOk = preg_match_all($sRegexRequests2, str_replace("\n", "", $sRequestData), $matches2);
+                    // ignore requests in states _ and . as these are already completed and closed
+                    if (strip_tags($matches2[0][3]) == '_' || strip_tags($matches2[0][3]) == '.') continue;
 
                     $aTmp = array();
                     $aTmp['Webserver'] = $sHostname;


### PR DESCRIPTION
Ignore requests in states `_` and `.` as they are already completed and closed.

These scoreboard entries should not be included in the data. Apache is showing them only because of performance - it is not wipeing old entries in scoreborad, just replacing them with new. Including closed requests in data, for example, highly distorts max requests from IP info.